### PR TITLE
fix:master password always correct

### DIFF
--- a/src/actions.py
+++ b/src/actions.py
@@ -290,8 +290,8 @@ def bruteforce_master_password(connection, wordlist_file=None):
     # Try each password
     for pwd in passwords:
         try:
-            url = connection.host.rstrip('/') + '/xmlrpc/2/db'
-            proxy = xmlrpc.client.ServerProxy(url, allow_none=True)
+            print(f"{Colors.i} Trying password: {pwd}")
+            proxy = connection.master  
 
             # Use `dump` as it requires correct master password
             proxy.dump(pwd, 'fake_db_73189')

--- a/src/connect.py
+++ b/src/connect.py
@@ -20,6 +20,7 @@ class Connection:
         self.session.verify = ssl_verify
         self.common_endpoint = f"{self.host}/xmlrpc/2/common"
         self.object_endpoint = f"{self.host}/xmlrpc/2/object"
+        self.master_password_endpoint = f"{self.host}/xmlrpc/2/db"
         
         # For authenticated operations
         self.uid = None
@@ -30,6 +31,7 @@ class Connection:
         if not ssl_verify:
             ssl_context = ssl._create_unverified_context()
             self.common = xmlrpc.client.ServerProxy(self.common_endpoint, context=ssl_context)
+            self.master = xmlrpc.client.ServerProxy(self.master_password_endpoint, context=ssl_context)
             self.models = None  # Will be initialized after authentication
         else:
             self.common = xmlrpc.client.ServerProxy(self.common_endpoint)


### PR DESCRIPTION
Added self.master XML-RPC client with optional SSL verification (ssl_verify=False by default).
Reused self.master in master password brute-force function to handle certificate issues.
Fixed the problem of master passwords always correct and avoid false positives.