### PR TITLE
Add support for database name bruteforce

### DIFF
--- a/src/connect.py
+++ b/src/connect.py
@@ -87,6 +87,38 @@ class Connection:
             return text
         return ''.join(c for c in text if c != '\x00' and ord(c) < 128 and c.isprintable())
 
+    def bruteforce_database(self, wordlist_file):
+        """Bruteforce database using a wordlist file"""
+        if not wordlist_file:
+            print(f"{Colors.e} No wordlist file specified for database bruteforce")
+            return False
+        
+        try:
+            with open(wordlist_file, 'r', encoding='utf-8', errors='ignore') as f:
+                databases = [line.strip() for line in f if line.strip()]
+        except Exception as e:
+            print(f"{Colors.e} Error reading wordlist file: {str(e)}")
+            return False
+
+        found_databases = []
+        for db in databases:
+            try:
+                uid = self.common.authenticate(db, "mm", "admin", {})
+                if uid == False:
+                    print(f"[+] Found DB: {db}")
+                    found_databases.append(db)
+            except Exception as e:
+                if "failed: FATAL:  database" in str(e) and "does not exist" in str(e):
+                    print(f"{Colors.e} Database {Colors.FAIL}{db}{Colors.ENDC} does not exist")
+
+
+        if found_databases:
+            print(f"{Colors.s} Found {len(found_databases)} valid database(s): {', '.join(found_databases)}")
+            return True
+        else:
+            print(f"{Colors.e} No valid databases found")
+            return False
+    
     def bruteforce_login(self, db, wordlist_file=None, usernames_file=None, passwords_file=None):
         """Bruteforce login using default or custom wordlist"""
         if not db:

--- a/src/core.py
+++ b/src/core.py
@@ -55,6 +55,10 @@ def parse_arguments():
     parser.add_argument('-M', '--bruteforce-master', action='store_true', help="Bruteforce the database's master password")
     parser.add_argument('-p','--master-pass', help='Wordlist file for master password bruteforce (one password per line)')
 
+    # bruteforce database names
+    parser.add_argument('-bd','--bruteforce-database', action='store_true', help='Bruteforce database names')
+    parser.add_argument('-f','--bruteforce-database-file', help='File containing database names for bruteforcing (one per line)')
+
     args = parser.parse_args()
     
     # Validate argument combinations
@@ -74,7 +78,7 @@ def main():
     auth_required_ops = args.enumerate or args.dump or args.permissions or args.bruteforce_models
 
     # Check if any action is specified (besides recon)
-    any_action = args.enumerate or args.dump or args.bruteforce or args.permissions or args.bruteforce_models or args.bruteforce_master
+    any_action = args.enumerate or args.dump or args.bruteforce or args.permissions or args.bruteforce_models or args.bruteforce_master or args.bruteforce_database
 
     # Determine if recon should be performed
     do_recon = args.recon or not any_action
@@ -157,6 +161,14 @@ def main():
         # Check default apps
         apps = connection.default_apps_check()
 
+    # --- Bruteforce database names if requested ---
+    if args.bruteforce_database:
+        if not args.bruteforce_database_file:
+            print(f"{Colors.w} No database names file provided.")
+            sys.exit(1)
+        print(f"{Colors.i} Bruteforcing database names using file: {args.bruteforce_database_file}")
+        connection.bruteforce_database(args.bruteforce_database_file)
+    
     # Bruteforce
     if args.bruteforce:
         print(f"{Colors.i} Starting bruteforce login...")


### PR DESCRIPTION
This PR adds functionality to bruteforce the Odoo database name via XML-RPC

this is the command to run it
`python odoomap.py -u https://example.com -bd -f path/to/file`